### PR TITLE
Avoid indexing data URIs for images #21

### DIFF
--- a/cosrlib/document/html/htmldocument.py
+++ b/cosrlib/document/html/htmldocument.py
@@ -170,7 +170,8 @@ class HTMLDocument(Document):
                 if attrs.get("alt"):
                     self.add_word_group(attrs["alt"], tag="img")
                 if attrs.get("src"):
-                    self.add_word_group(" ".join(self._split_filename_words(attrs["src"])), tag="img")
+                    if not attrs["src"].startswith("data:"):
+                        self.add_word_group(" ".join(self._split_filename_words(attrs["src"])), tag="img")
 
             # Does this element start a hidden subtree?
             if self.level_hidden is None and self._guess_element_hidden(attrs):

--- a/tests/cosrlibtests/document/html/test_word_groups.py
+++ b/tests/cosrlibtests/document/html/test_word_groups.py
@@ -93,6 +93,16 @@ SAMPLES = [
             ["p", "post"]
         ]
     },
+
+    # IMG with dataURIs are ignored
+    {
+        "html": """<p> pre <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" alt="Red dot" /> post </p>""",
+        "groups": [
+            ["p", "pre"],
+            ["img", "Red dot"],
+            ["p", "post"]
+        ]
+    },
 ]
 
 


### PR DESCRIPTION
not sure how careful we should be about performance issues. I avoided regexes, but still used `startswith` which is not the fastest way to check apparently, but the difference doesn't look too big. 

We could be a more precise by validating the whole format (a comma should be present after the `data:` and there should be some alphanumerical characters)