### PR TITLE
#29 URL.normalized: strip default ports

### DIFF
--- a/cosrlib/url.py
+++ b/cosrlib/url.py
@@ -99,6 +99,10 @@ class URL(object):
                 value = self.domain[4:]
             else:
                 value = self.domain
+            if value.endswith(':80'):
+                value = value[:-3]
+            elif value.endswith(':443'):
+                value = value[:-4]
 
         elif attr == "normalized_subdomain":
             if self.subdomain.startswith("www."):

--- a/tests/cosrlibtests/test_url.py
+++ b/tests/cosrlibtests/test_url.py
@@ -1,7 +1,8 @@
+import pytest
+from cosrlib.url import URL
+
 
 def test_url():
-    from cosrlib.url import URL
-
     assert URL("https://www.test.com").normalized == "test.com"
     assert URL("https://www.test.com?").normalized == "test.com"
     assert URL("https://www.test.com?").normalized_domain == "test.com"
@@ -24,3 +25,14 @@ def test_url():
     assert URL("http://sub.test.co.uk/azerza/azer.html?x=a#b").homepage == "http://sub.test.co.uk"
 
     assert URL('http://dc.weber.edu/\xc3\xaf\xc2\xbf\xc2\xbd/field/?a=b&c=d&e=\xc3\xaf\xc2\xbf\xc2\xbd#qq', check_encoding=True).url == "http://dc.weber.edu/%C3%AF%C2%BF%C2%BD/field/?a=b&c=d&e=%C3%AF%C2%BF%C2%BD#qq"
+
+
+@pytest.mark.parametrize('url,normalized_domain,normalized', [
+    ('http://example.org:8080/foo', 'example.org:8080', 'example.org:8080/foo'),
+    ('http://example.org:80/foo', 'example.org', 'example.org/foo'),
+    ('https://example.org:443', 'example.org', 'example.org')
+    ])
+def test_normalize(url, normalized_domain, normalized):
+    _url = URL(url)
+    assert _url.normalized_domain == normalized_domain
+    assert _url.normalized == normalized


### PR DESCRIPTION
Tiny PR for #29 to strip default HTTP/HTTPS port from normalized URLs.

Only verified with:

```
py.test tests/ -v -m "not elasticsearch"