### PR TITLE
Updated Common crawl to Feb 2016 crawl

### DIFF
--- a/scripts/import_commoncrawl.sh
+++ b/scripts/import_commoncrawl.sh
@@ -10,7 +10,7 @@
 WARC_COUNT=${1:-1}
 
 # Common Crawl ID. See http://blog.commoncrawl.org/ for latest dumps
-COMMONCRAWL_ID=${COMMONCRAWL_ID:-CC-MAIN-2015-48}
+COMMONCRAWL_ID=${COMMONCRAWL_ID:-CC-MAIN-2016-07}
 
 mkdir -p local-data/common-crawl/crawl-data
 


### PR DESCRIPTION
This PR aims to fix issue #24 updating common crawl to February 2016 crawl (2016-07).

```bash
ls -R local-data/
common-crawl

local-data//common-crawl:
crawl-data     warc.paths.txt

local-data//common-crawl/crawl-data:
CC-MAIN-2016-07

local-data//common-crawl/crawl-data/CC-MAIN-2016-07:
segments

local-data//common-crawl/crawl-data/CC-MAIN-2016-07/segments:
1454701145519.33

local-data//common-crawl/crawl-data/CC-MAIN-2016-07/segments/1454701145519.33:
warc

local-data//common-crawl/crawl-data/CC-MAIN-2016-07/segments/1454701145519.33/warc:
CC-MAIN-20160205193905-00000-ip-10-236-182-209.ec2.internal.warc.gz
```