### PR TITLE
Run the tests inside a Docker-compose environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_install:
 
   # Start the Elasticsearch service
   - docker pull commonsearch/local-elasticsearch
-  - docker run -d -p 39200:9200 -p 39300:9300 commonsearch/local-elasticsearch
 
   - ./scripts/git-set-file-times
 
@@ -46,14 +45,6 @@ before_install:
     rm -rf $HOME/.cache/docker/* &&
     sh -c "docker save commonsearch/local-back $(docker history -q commonsearch/local-back | tail -n +2 | grep -v \<missing\> | tr '\n' ' ') | gzip > $HOME/.cache/docker/image.tgz";
     fi
-
-  # Make sure the networking to the container running Elasticsearch is OK
-  - ps -ef
-  - netstat -lpn
-  - docker run commonsearch/local-back ip route show 0.0.0.0/0
-  - docker run commonsearch/local-back cat /etc/hosts
-  - curl "http://127.0.0.1:39200"
-  - docker run -e COSR_ELASTICSEARCHTEXT commonsearch/local-back curl $COSR_ELASTICSEARCHTEXT
 
 script:
   - make docker_pylint

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -1,0 +1,41 @@
+version: '2'
+services:
+
+  elasticsearch:
+    image: commonsearch/local-elasticsearch
+
+  urlserver:
+    image: commonsearch/local-back
+    command: python urlserver/server.py
+    volumes:
+     - .:/cosr/back:rw
+    working_dir: /cosr/back
+    depends_on:
+     - elasticsearch
+    links:
+     - elasticsearch
+    environment:
+        # Use the elasticsearch instance running the linked container
+      - "COSR_ELASTICSEARCHDOCS=elasticsearch:9200"
+      - "COSR_ELASTICSEARCHTEXT=elasticsearch:9200"
+
+  tester:
+    image: commonsearch/local-back
+    command: make test
+    environment:
+      - "TRAVIS"
+      - "TRAVIS_BRANCH"
+      - "TRAVIS_JOB_ID"
+      - "COSR_ENV"
+      - "TERM=xterm-256color"
+      - "COSR_ELASTICSEARCHDOCS=elasticsearch:9200"
+      - "COSR_ELASTICSEARCHTEXT=elasticsearch:9200"
+    depends_on:
+      - elasticsearch
+      - urlserver
+    links:
+      - elasticsearch
+      - urlserver
+    volumes:
+     - .:/cosr/back:rw
+    working_dir: /cosr/back


### PR DESCRIPTION
* this starts automatically all the necessary containers
* and waits for elasticsearch
* use a custom environment variable for the elasticsearch URL

Fixes #64 