### PR TITLE
Use only python 2.7 for virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ clean_coverage:
 # Creates a local Python virtualenv with all required modules installed
 virtualenv:
 	rm -rf venv
-	virtualenv venv --distribute
+	virtualenv -p python2.7 venv --distribute
 
 	# Cython must be installed prior to gumbocy. TODO: how to fix that?
 	grep -i Cython requirements.txt | xargs venv/bin/pip install


### PR DESCRIPTION
To address the issue where python3 is automatically selected
for virtualenv:
https://github.com/commonsearch/cosr-back/issues/71
